### PR TITLE
Fix CSS not loading in production build

### DIFF
--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import '../styles/global.css';
+
 interface Props {
   title?: string;
   description?: string;
@@ -21,7 +23,6 @@ const {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@600&display=swap" rel="stylesheet">
     <link href="https://fonts.cdnfonts.com/css/liter" rel="stylesheet">
-    <link rel="stylesheet" href="/src/styles/global.css" />
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
- Import global.css in frontmatter instead of using <link> tag
- Astro now processes CSS through Vite and generates hashed file in _astro/
- CSS now loads correctly in deployed site

This fixes the missing styles issue on GitHub Pages.