### PR TITLE
Add AI projects announcement banner to homepage

### DIFF
--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -131,7 +131,7 @@ const formatDate = (date: Date) => {
   </section>
 
   <div class="note">
-    I've been tinkering with AI — check out what I've been building on my <a href="https://kenneth.dsouza.im/ai/" target="_blank" rel="noopener noreferrer">AI Projects<span class="sr-only"> (opens in new tab)</span></a> page.
+    I've been tinkering with AI — check out what I've been building on my <a href="https://kenneth.dsouza.im/ai/" target="_blank" rel="noopener noreferrer">AI Projects<span class="sr-only"> (opens in new tab)</span></a> page
   </div>
 
   <!-- Work Section -->

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -131,7 +131,7 @@ const formatDate = (date: Date) => {
   </section>
 
   <div class="note">
-    I've been experimenting with AI — see what I've been building on my <a href="https://kenneth.dsouza.im/ai/" target="_blank" rel="noopener noreferrer">AI Projects<span class="sr-only"> (opens in new tab)</span></a> page.
+    I've been tinkering with AI — check out what I've been building on my <a href="https://kenneth.dsouza.im/ai/" target="_blank" rel="noopener noreferrer">AI Projects<span class="sr-only"> (opens in new tab)</span></a> page.
   </div>
 
   <!-- Work Section -->

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -130,6 +130,10 @@ const formatDate = (date: Date) => {
     </div>
   </section>
 
+  <div class="note">
+    I've been experimenting with AI — see what I've been building on my <a href="https://kenneth.dsouza.im/ai/" target="_blank" rel="noopener noreferrer">AI Projects<span class="sr-only"> (opens in new tab)</span></a> page.
+  </div>
+
   <!-- Work Section -->
   <section>
     <div class="section-header">

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -542,7 +542,6 @@ figcaption {
   grid-template-columns: 1fr auto;
   gap: 2rem;
   align-items: start;
-  margin-bottom: 3rem;
 }
 
 .intro-text h1 {


### PR DESCRIPTION
## Summary
Added a prominent announcement banner to the homepage highlighting AI projects, and adjusted spacing in the intro section.

## Key Changes
- Added a new `.note` div section on the homepage with a link to the AI Projects page
- Included accessible link markup with `sr-only` span for screen reader users
- Removed `margin-bottom: 3rem` from the `.intro-text` grid styling to adjust spacing

## Implementation Details
- The announcement banner is positioned after the intro section and before the Work section
- The link opens in a new tab with proper security attributes (`target="_blank" rel="noopener noreferrer"`)
- Accessibility is maintained with a screen reader-only label indicating the link opens in a new tab

https://claude.ai/code/session_01GtFH69rpnUQvRHcBmyku2P